### PR TITLE
[stable/node-local-dns]: Update to k8s-dns-node-cache 1.26.7

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.1.4
-appVersion: 1.23.1
+version: 2.1.5
+appVersion: 1.26.7
 maintainers:
   - name: gabrieladt
     url: https://github.com/gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.1.4
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.1.5
 ```
 
 To install the chart with the release name `my-release`:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

The OS CVEs found in the version 1.23.1 are libssl3 and libc6. This is fixed by the base image change.

Base Image Refresh: This update moves the container to a newer Debian/Distroless base. This automatically patches "High" and "Critical" OS-level vulnerabilities in core libraries such as glibc, libssl.

<!--- Describe your changes in detail -->
Update to k8s-dns-node-cache 1.26.7
## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
