### PR TITLE
[stable/node-local-dns]: Update to k8s-dns-node-cache 1.26.7 and bump version to 2.1.6

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.1.5
-appVersion: 1.23.1
+version: 2.1.6
+appVersion: 1.26.7
 maintainers:
   - name: gabrieladt
     url: https://github.com/gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+![Version: 2.1.6](https://img.shields.io/badge/Version-2.1.6-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.1.4
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.1.6
 ```
 
 To install the chart with the release name `my-release`:
@@ -50,6 +50,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.bindIp | bool | `false` | If false, it will bind 0.0.0.0, otherwise dnsServer and localDns will be used. https://github.com/bottlerocket-os/bottlerocket/issues/3711#issuecomment-1907087528 |
+| config.cache | object | `{"enabled":false,"ttl":""}` | If enabled, coredns will cache the items |
 | config.commProtocol | string | `"force_tcp"` | Set communication protocol. Options are `prefer_udp` or `force_tcp` |
 | config.customConfig | string | `""` | Overrides the generated configuration with specified one. |
 | config.customUpstreamsvc | string | `""` | Use a custom upstreamsvc for -upstreamsvc |
@@ -60,7 +61,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 | config.healthPort | int | `8080` | Port used for the health endpoint |
 | config.localDns | string | `"169.254.20.25"` |  |
 | config.noIPv6Lookups | bool | `false` | If true, return NOERROR when attempting to resolve an IPv6 address |
-| config.prefetch | object | `{"amount":3,"duration":"30s","enabled":false,"percentage":"20%"}` | If enabled, coredns will prefetch popular items when they are about to be expunged from the cache. https://coredns.io/plugins/cache/ |
+| config.prefetch | object | `{"amount":3,"duration":"60s","enabled":false,"percentage":"20%"}` | If enabled, coredns will prefetch popular items when they are about to be expunged from the cache. https://coredns.io/plugins/cache/ |
 | config.setupInterface | bool | `true` |  |
 | config.setupIptables | bool | `true` |  |
 | config.skipTeardown | bool | `false` |  |


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Update to k8s-dns-node-cache 1.26.7 and bump version to 2.1.6
The OS CVEs found in the version 1.23.1 are libssl3 and libc6. This is fixed by the base image change.

<!--- Describe your changes in detail -->
Updated the appVersion to _1.26.7_  which fixes the OS CVEs reported in [JIRA](https://new-relic.atlassian.net/browse/NR-513480). The image is already mirrored. [cf-registry.nr-ops.net/registry.k8s.io/dns/k8s-dns-node-cache:1.26.7]

Also, releasing the new chart version to 2.1.6.

## Checklist
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
