### PR TITLE
[stable/node-local-dns] fix: mitigate DNS disruption during node-local-dns DaemonSet rollouts

### DIFF
--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 10%
+      maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: {{ include "node-local-dns.name" . }}
@@ -102,6 +102,7 @@ spec:
           mountPath: /etc/coredns
         - name: kube-dns-config
           mountPath: /etc/kube-dns
+      terminationGracePeriodSeconds: 60    
       volumes:
       - name: xtables-lock
         hostPath:


### PR DESCRIPTION
## Summary

During node-local-dns DaemonSet rolling updates, apps experience DNS resolution failures (e.g. browser-connect-service failing to resolve vortex.ingest.svc.cluster.local). This happens because of a race condition in the upstream k8s-dns-node-cache shutdown sequence: iptables rules that redirect DNS traffic to the local cache are torn down AFTER the DNS server stops listening, creating a blackhole window where queries are sent to an IP with nothing serving them.

This PR mitigates the issue with two changes:

  - **Reduce `maxUnavailable` from 10% to 1** — limits the blast radius to a single node at a time instead of ~35 nodes (e.g. us-pink-flamingo has 359 pods). Rollouts will be slower but safer.
  - **Set `terminationGracePeriodSeconds` to 60s** — gives the teardown process more time to complete before SIGKILL (default was 30s).

These are mitigations, not a fix. The root cause is an architectural issue in upstream kubernetes/dns (tested up to 1.26.7): `TeardownNetworking()` is registered as a `caddy.OnProcessExit` hook, which runs after Caddy stops its DNS listeners. A proper fix would require either a source code change to intercept SIGTERM before Caddy processes it, or a `preStop` lifecycle hook to tear down networking while DNS is still serving.

## Test plan

- [ ] Deploy to a staging or production cluster and trigger a rollout
- [ ] Monitor DNS resolution errors during the rollout
- [ ] Verify rollout completes successfully (just slower)

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
